### PR TITLE
added HEAD verb support

### DIFF
--- a/http_server.rb
+++ b/http_server.rb
@@ -5,7 +5,7 @@ socket = TCPServer.new(80)
 loop do
   client = socket.accept
   first_line = client.gets
-  verb, path, _ = first_line.split
+  verb, path = first_line.split.first(2)
 
   if verb == 'GET'
     if result = path.match(/^\/customers\/(.*?)$/)
@@ -14,6 +14,12 @@ loop do
       body.gsub!('{{user_id}}', user_id)
       status = 200
       response = "HTTP/1.1 #{status}\r\nContent-Type: text/html\r\n\r\n#{body}"
+      client.puts(response)
+    end
+  elsif verb == "HEAD"
+    if result = path.match(/^\/customers\/(.*?)$/)
+      status = 200
+      response = "HTTP/1.1 #{status}\r\nContent-Type: text/html\r\n\r\n"
       client.puts(response)
     end
   end


### PR DESCRIPTION
According to the HTTP 1.1 specification, a server must minimally respond to GET and HEAD to be compliant. HEAD response now implemented in the most primitive way.